### PR TITLE
Cria rotina de execucao em bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ config.json
 doc/*
 *.html
 .vscode/
+
+logs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A visão do MainSystem se comunica com o ALP-Winners utilizando sockets. ALP-GUI
 pip install -r requirements.txt
 ```
 
-2. Digital no termianl 
+2. Digitar no terminal 
 
 `./run.sh`
 

--- a/README.md
+++ b/README.md
@@ -11,27 +11,21 @@ A visão do MainSystem se comunica com o ALP-Winners utilizando sockets. ALP-GUI
 pip install -r requirements.txt
 ```
 
-2. Abrir dois terminais para execução simultânea do MainSystem e ALP-Winners
+2. Digital no termianl 
 
-3. No terminal 1, mover para o diretório MainSystem e executar com:
-```
-./main.py --port 5001 --n_robots 3
+`./run.sh`
 
-```
+Isso irá executar o sistema com a configuração padrão de porta `5001`. Caso haja algum problema com essa porta, é possível executar o MALP com o comando
 
-4. No terminal 2, mover para o diretório ALP-Winners e executar com:
-```
-python3 src/main.py --port 5001
-```
+`./run.sh 5002`
 
-## Para debug
-
-Para debugar, basta incluir como argumento ```--debug``` tanto quando for executar o MainSystem quanto o ALP-Winners. Por enquanto, as unicas informações que o sistema entrega no modo de debug é o tempo do loop.
+Ou com qualquer outra porta que desejar. 
 
 > ### Importante!!
 >
-> - Executar os comandos do MainSystem antes de executar os do ALP-Winners para estabelecer a comunicação entre os sistemas
-> - Observar se a porta 5001 está sendo utilizada por outra aplicação. Caso esteja em uso, basta trocar para 5002, 5003, e assim por diante. O conflito dessas portas costuma ocorrer quando houve algum erro no MALP
+> - A interface gráfica do MainSystem não é finalizada quando o bash run.sh é finalizado no terminal
+> - Caso queira fazer debug usando prints, é recomendado colocar no print o nome do sistema proveniente ou executar os sistemas manualmente em terminais separados
+> - Caso queira usar outros argumentos antes de executar, basta alterar o arquivo run.sh na linha 10
 
 ## Comunicação MALP com robô
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,3 @@
-#!/bin/zsh
 mkdir -p logs
 
 PORTA="5001"

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,10 @@
+#!/bin/zsh
+mkdir -p logs
+
+PORTA="5001"
+
+if [[ -n $1 ]]; then
+    PORTA="$1"
+fi
+
+( (cd MainSystem && ./main.py --port "$PORTA") & (sleep 0.5s && python3 ALP-Winners/src/main.py --port "$PORTA") )


### PR DESCRIPTION
Para executar o sistema na porta padrão (5001), basta digitar 

`./run.sh`

Se der conflito na porta, pode trocar digitando 

`./run.sh 5002`

Ou o número que for preciso. 

## Alguns cuidados
Ao usar prints para debug, tomar cuidado pois todas as informações dos dois sistemas que vão para o terminal, vão sem identificação. Nesse caso, recomendo ou colocar o nome do sistema de onde vem o print ou executar os dois sistemas manualmente, como é feito atualmente. Para usar a flag `debug`, ou qualquer outro argumento que vem do terminal, é necessário alterar o arquivo `run.sh` na linha 10. 

A interface gráfica do Mainsystem não é finalizada. 
